### PR TITLE
fix(drawer):Fix the destroy function does not correctly mark _status as 'DESTROY'

### DIFF
--- a/packages/drawer/src/index.ts
+++ b/packages/drawer/src/index.ts
@@ -362,8 +362,8 @@ export default class Drawer {
   }
 
   destroy(): void {
-    this._status = 'DESTROY';
     this.reset();
+    this._status = 'DESTROY';
     this.mouseTooltip.destroy();
     this._subscriber.destroy();
   }


### PR DESCRIPTION
Changed the execution time of the reset() to after modifying _status