### PR TITLE
fix(primitive-geojson):修复多孔polygon显示问题

### DIFF
--- a/packages/primitive-geojson/src/GeoJsonLayer-util.ts
+++ b/packages/primitive-geojson/src/GeoJsonLayer-util.ts
@@ -291,19 +291,20 @@ export function createPolygon(
   }
   const properties = geoJson.properties ?? {};
 
-  const positions = coordinatesArrayToCartesianArray(
-    coordinates[0],
-    crsFunction,
-  );
+  const cartesian3Coords = coordinates.map((it) => coordinatesArrayToCartesianArray(
+    it,
+    crsFunction
+  ));
   geoJsonLayer.addPolygon({
-    type: 'Polygon',
-    positions,
+    type: "Polygon",
+    positions: cartesian3Coords[0],
+    holes: cartesian3Coords.slice(1),
     style: {
       material: options.fill,
       outlineColor: options.stroke,
-      outlineWidth: options.strokeWidth,
+      outlineWidth: options.strokeWidth
     },
-    properties,
+    properties
   });
 }
 

--- a/packages/primitive-geojson/src/GeoJsonPrimitiveLayer.ts
+++ b/packages/primitive-geojson/src/GeoJsonPrimitiveLayer.ts
@@ -331,7 +331,7 @@ export class GeoJsonPrimitiveLayer extends BasicGraphicLayer {
     const id = this._generateId();
 
     const geometry = new PolygonGeometry({
-      polygonHierarchy: new PolygonHierarchy(positions, holes.map(it => new PolygonHierarchy(hole))),
+      polygonHierarchy: new PolygonHierarchy(positions, holes.map(hole => new PolygonHierarchy(hole))),
       vertexFormat: PerInstanceColorAppearance.VERTEX_FORMAT,
       extrudedHeight: style?.extrudedHeight,
       arcType: ArcType.RHUMB,

--- a/packages/primitive-geojson/src/GeoJsonPrimitiveLayer.ts
+++ b/packages/primitive-geojson/src/GeoJsonPrimitiveLayer.ts
@@ -327,11 +327,11 @@ export class GeoJsonPrimitiveLayer extends BasicGraphicLayer {
   }
 
   addPolygon(item: PolygonPrimitiveItem) {
-    const { positions, style } = item;
+    const { positions, style, holes } = item;
     const id = this._generateId();
 
     const geometry = new PolygonGeometry({
-      polygonHierarchy: new PolygonHierarchy(positions),
+      polygonHierarchy: new PolygonHierarchy(positions, holes.map(it => new PolygonHierarchy(hole))),
       vertexFormat: PerInstanceColorAppearance.VERTEX_FORMAT,
       extrudedHeight: style?.extrudedHeight,
       arcType: ArcType.RHUMB,

--- a/packages/primitive-geojson/src/typings.ts
+++ b/packages/primitive-geojson/src/typings.ts
@@ -87,6 +87,7 @@ export type LabelPrimitiveItem = {
 export type PolygonPrimitiveItem = {
   type: 'Polygon';
   positions: Cartesian3[];
+  holes: Cartesian3[][];
   style?: {
     material?: Color;
     /**The distance in meters between the polygon and the ellipsoid surface. */


### PR DESCRIPTION
修复polygon多孔显示问题
示例geojson：{"features":[{"geometry":{"coordinates":[[[[113.97614516760989,22.608130124267554],[113.97713097604758,22.682103418382248],[114.12138825725599,22.687691376647344],[114.10973682208753,22.612094415920218],[114.1009238211049,22.61209437005258],[114.1009238211049,22.587553961770972],[113.99869559170513,22.587553961770972],[113.99869559170513,22.607994725099196],[113.97614516760989,22.608130124267554]],[[114.06990382192491,22.654962223125985],[114.02477375255732,22.65168040861412],[114.02551218495539,22.629088501083096],[114.06905723294078,22.629088501083096],[114.06990382192491,22.654962223125985]]]],"type":"MultiPolygon"},"properties":{},"type":"Feature"}],"type":"FeatureCollection"}